### PR TITLE
feat: add async poll util

### DIFF
--- a/.changeset/itchy-moles-explode.md
+++ b/.changeset/itchy-moles-explode.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": minor
+---
+
+feat: add async poll util

--- a/src/errors/poll-timeout.ts
+++ b/src/errors/poll-timeout.ts
@@ -1,0 +1,10 @@
+import { HexgateError } from './index.js'
+
+/**
+ * Thrown when the maximum number of retries is exceeded.
+ */
+export class PollTimeoutError extends HexgateError {
+  constructor() {
+    super('Polling timeout! Max retries exceeded', 'timeout')
+  }
+}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,1 +1,1 @@
-export type ErrorKind = 'invalid' | 'missing'
+export type ErrorKind = 'invalid' | 'missing' | 'timeout' | 'unknown'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { poll } from './poll.js'

--- a/src/utils/poll.ts
+++ b/src/utils/poll.ts
@@ -1,0 +1,32 @@
+import { PollTimeoutError } from 'hexgate/errors/poll-timeout.js'
+
+/**
+ * Retry a function until an error is not thrown.
+ * @param fn - The function to retry.
+ * @param interval - The interval in milliseconds to wait between retries.
+ * @param max - The maximum number of retries. If undefined, will retry indefinitely.
+ * @param onRetry - A function to execute after each failed attempt.
+ *
+ * @example
+ * ```ts
+ * const credentials = await poll(authenticate, 5000)
+ * ```
+ */
+export async function poll<T>(
+  fn: () => Promise<T>,
+  interval = 5000,
+  max = 5,
+  onRetry?: () => void
+): Promise<T> {
+  try {
+    return await fn()
+  } catch {
+    if (max !== undefined) {
+      if (max === 0) throw new PollTimeoutError()
+      max--
+    }
+    onRetry?.()
+    await new Promise((resolve) => setTimeout(resolve, interval))
+    return poll(fn, interval, max, onRetry)
+  }
+}


### PR DESCRIPTION
Util for retrying an async function that may fail.

example:

```ts
import { auth } from "hexgate"
import { poll } from "hexgate/utils"

const credentials = poll(auth)
```

this example uses the default args, but utilizes the onRetry callback to print a message between attempts:

```ts
const credentials = await poll(auth, 5000, 5, () => console.log("retrying in 5 seconds..."))
```