### PR TITLE
feat: add `Result` util to the recipe api + "phantom" error typings

### DIFF
--- a/.changeset/eighty-pumpkins-do.md
+++ b/.changeset/eighty-pumpkins-do.md
@@ -1,0 +1,5 @@
+---
+"hexgate": minor
+---
+
+feat: add `Result` util to the recipe api + "phantom" error typings

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { mapDefined } from './utils/map-defined.js'
 export { poll } from './utils/poll.js'
 export { proxyFunction } from './utils/proxy-function.js'
 export { proxyFlyweight } from './utils/proxy-flyweight.js'
+export { result } from './utils/result.js'
 
 /// Errors
 export { HexgateError } from './errors/index.js'
@@ -73,4 +74,13 @@ export type {
   OperationResponses
 } from './types/hexgate/operation.js'
 
-export type { ApiResponse } from '@cuppachino/openapi-fetch'
+export type {
+  ApiResponse,
+  ApiError,
+  CreateFetch,
+  CustomRequestInit,
+  Fetch
+} from '@cuppachino/openapi-fetch'
+
+export type { Phantom, PhantomError, PhantomSymbol } from './types/phantom.js'
+export type { Err, IntoResult, Ok, Result } from './types/result.js'

--- a/src/modules/hexgate/recipe.ts
+++ b/src/modules/hexgate/recipe.ts
@@ -2,6 +2,7 @@ import type { RecipeApi } from '../../types/hexgate/recipe.js'
 import { extractData as unwrap } from '../../utils/extract-data.js'
 import { proxyFlyweight as once } from '../../utils/proxy-flyweight.js'
 import { proxyFunction as wrap } from '../../utils/proxy-function.js'
+import { result } from '../../utils/result.js'
 import type { Hexgate } from './index.js'
 
 /**
@@ -15,17 +16,18 @@ import type { Hexgate } from './index.js'
  * - `wrap` - Use this to wrap a function, and transform it's parameters and return values with automatic type inference.
  * - `unwrap` - Curried convenience method for unwrapping the `data` property of a response. The first call takes an optional error message. The second call will extract the `data` property from the response.
  * - `once` - Use this to create a flyweight proxy by supplying a record of async handlers. The first time a property is accessed, the handler is called, the result is cached, and the promise is returned. Subsequent accesses will return the cached promise.
- *
+ * - `result` - Which can be used to represent a successful or failed request. See the `result` utility function for more information.
  * @returns The recipe, which takes a `Hexgate` instance and returns `U`.
  */
 export function createRecipe<T extends Hexgate, U>(
-  api: ({ build, wrap, unwrap, once }: RecipeApi) => U
+  api: ({ build, wrap, unwrap, once, result }: RecipeApi) => U
 ) {
   return (hexgate: T): U =>
     api({
       build: hexgate['build'],
       wrap,
       unwrap,
-      once
+      once,
+      result
     })
 }

--- a/src/types/hexgate/recipe.ts
+++ b/src/types/hexgate/recipe.ts
@@ -2,11 +2,13 @@ import type { proxyFunction } from '../../utils/proxy-function.js'
 import type { proxyFlyweight } from '../../utils/proxy-flyweight.js'
 import type { extractData } from '../../utils/extract-data.js'
 import type { HexgateBuild } from './fetcher.js'
+import type { result } from '../../utils/result.js'
 
 export interface RecipeUtils {
   wrap: typeof proxyFunction
   unwrap: typeof extractData
   once: typeof proxyFlyweight
+  result: typeof result
 }
 
 export interface RecipeApi extends RecipeUtils {

--- a/src/types/phantom.ts
+++ b/src/types/phantom.ts
@@ -1,0 +1,43 @@
+/**
+ * "Fake" unique symbol used internally for additional type inference.
+ * @internal
+ */
+declare const internalPhantomSymbol: unique symbol
+
+/**
+ * A unique symbol type used internally for additional type inference.
+ * @internal
+ */
+export type PhantomSymbol = typeof internalPhantomSymbol
+
+/**
+ * Internal utility for dangerous type inference. Only use this if you know what you're doing.
+ * If the type already has the symbol, it is returned as-is.
+ * @see {@link PhantomError}
+ */
+export type Phantom<T, U = never> = T extends { [P in PhantomSymbol]?: [U] }
+  ? T
+  : T & { [P in PhantomSymbol]?: [U] }
+
+/**
+ * Convert the `Phantom` type to an interface
+ * that can be implemented by a class.
+ * @internal
+ */
+interface PhantomContainer<E> extends Phantom<unknown, E> {}
+
+/**
+ * "Fake" class for preventing indexed access
+ * @internal
+ */
+declare class PhantomContainer<E> implements PhantomContainer<E> {}
+
+/**
+ * Intersect the internal hint type with the actual error type.
+ * This allows us to add a hint to the error type, without affecting the actual error type.
+ * @see {@link Phantom}
+ */
+export type PhantomError<
+  Expect,
+  ErrorType = unknown
+> = PhantomContainer<Expect> & ErrorType

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,0 +1,49 @@
+import type { PhantomError } from './phantom.js'
+
+/**
+ * Wrap a type in an "is ok" state.
+ * @see {@link Err}
+ * @see {@link Result}
+ */
+export type Ok<T> = {
+  isOk: true
+  unwrap(): T
+}
+
+/**
+ * Wrap a type in an "is error" state.
+ * @see {@link Ok}
+ * @see {@link Result}
+ */
+export type Err<E> = {
+  isOk: false
+  unwrap: () => E
+}
+
+/**
+ * A union type of {@link Ok} and {@link Err}.
+ */
+export type Result<T, E> = Ok<T> | Err<E>
+
+/**
+ * Convert an async function to a function that returns a {@link Result} type.
+ * @param fn The function to convert.
+ * @returns A function that returns a {@link Result} type.
+ * @example
+ * ```ts
+ * const fetchUser = intoResult(async (id: number) => ...)<'user not found', Error>
+ * const user = await fetchUser(1)
+ * if (user.isOk) {
+ *  // user.value is of type User
+ * } else {
+ * // user.error is of type Error
+ * }
+ * ```
+ * @see {@link Ok}
+ * @see {@link Err}
+ */
+export type IntoResult<
+  T extends (...args: any[]) => any,
+  Expect,
+  ErrorType
+> = Result<Awaited<ReturnType<T>>, PhantomError<Expect, ErrorType>>

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,0 +1,55 @@
+import type { IntoResult } from '../types/result.js'
+
+/**
+ * Convert an async function to a function that returns a `result` type.
+ * @param fn The function to convert.
+ * @returns A function that returns a `result` type.
+ * @example
+ * ```ts
+ * import { type ApiError, createHexgate, createRecipe, result } from 'hexgate'
+ *
+ * const $recipe = createRecipe(
+ *   ({ build }) =>
+ *     result(build('/lol-lobby/v2/lobby').method('get').create())<
+ *       'Is there a lobby?',
+ *       ApiError
+ *     >
+ * )
+ *
+ * const getLobby = $recipe(createHexgate(await auth()))
+ *
+ * getLobby().then((res) => {
+ *   if (res.isOk) {
+ *     const { data } = res.unwrap()
+ *     console.log(data)
+ *   } else {
+ *     try {
+ *       res.unwrap()
+ *     } catch (err) {
+ *       console.error(err)
+ *     }
+ *   }
+ * })
+ * ```
+ * @see {@link IntoResult}
+ */
+export function result<T extends (...args: any[]) => Promise<any>>(fn: T) {
+  return async <Expect extends string = 'unknown error', ErrorType = unknown>(
+    ...args: Parameters<T>
+  ): Promise<IntoResult<T, Expect, ErrorType>> => {
+    try {
+      const value = await fn(...args)
+      return {
+        isOk: true,
+        unwrap: () => value
+      }
+    } catch (error) {
+      return {
+        isOk: false,
+        unwrap: () => {
+          throw error as ErrorType
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
```ts
import { type ApiError, createHexgate, createRecipe, result } from 'hexgate'
const $recipe = createRecipe(
  ({ build }) =>
    result(build('/lol-lobby/v2/lobby').method('get').create())<
      'Is there a lobby?',
      ApiError
    >
)
const getLobby = $recipe(createHexgate(await auth()))
getLobby().then((res) => {
  if (res.isOk) {
    const { data } = res.unwrap()
    console.log(data)
  } else {
    try {
      res.unwrap()
    } catch (err) {
      console.error(err)
    }
  }
})
```