### PR TITLE
Feat: Runner

### DIFF
--- a/.changeset/spotty-socks-occur.md
+++ b/.changeset/spotty-socks-occur.md
@@ -1,0 +1,5 @@
+---
+"hexgate": patch
+---
+
+Feat: Runner

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export { createRequestInit } from './modules/https/request-init.js'
 export { LcuClient, createLcuClient } from './modules/websocket/index.js'
 export type { ILcuClient } from './modules/websocket/index.js'
 
+/// Runner
+export { Runner } from './modules/runner/index.js'
+export type { StatusUpdate } from './modules/runner/index.js'
+
 /// Utilities
 export { extractData } from './utils/extract-data.js'
 export { identity } from './utils/identity.js'

--- a/src/modules/runner/index.ts
+++ b/src/modules/runner/index.ts
@@ -1,0 +1,109 @@
+import type { RequestInit, Response } from 'node-fetch-commonjs'
+import type { Credentials } from '../../types/tokens.js'
+import { createHexgate } from '../hexgate/create.js'
+import type { Hexgate } from '../hexgate/index.js'
+import type { createRecipe } from '../hexgate/recipe.js'
+import { createRequestInit } from '../https/request-init.js'
+import { Observable } from '../../utils/observable.js'
+
+export type StatusUpdate =
+  | {
+      status: 'disconnected' | 'connecting'
+      connected: false
+      credentials: undefined
+    }
+  | {
+      status: 'connecting'
+      connected: false
+      credentials: undefined
+    }
+  | {
+      status: 'connected'
+      connected: true
+      credentials: Credentials
+    }
+
+export class Runner<T extends ReturnType<typeof createRecipe>> {
+  #status: StatusUpdate['status']
+  #connected: Observable<boolean>
+  #credentials: Credentials | undefined
+  #init: RequestInit | undefined
+  #hexgate: Hexgate | undefined
+  #recipe: T
+  #cookbook: ReturnType<T> | undefined
+
+  get status() {
+    return this.#status
+  }
+
+  get connected() {
+    return this.#connected.value
+  }
+
+  get credentials() {
+    return this.#credentials
+  }
+
+  constructor(recipe: T) {
+    this.#recipe = recipe
+    this.#connected = new Observable(false)
+    this.#status = 'disconnected'
+  }
+
+  update = (status: StatusUpdate) => {
+    if (status.connected) {
+      this.#hexgate = createHexgate(status.credentials)
+      this.#init = createRequestInit(status.credentials)
+      this.#cookbook = this.#recipe(this.#hexgate) as ReturnType<T>
+    } else {
+      this.#hexgate = undefined
+      this.#init = undefined
+      this.#cookbook = undefined
+    }
+    this.#status = status.status
+    this.#credentials = status.credentials
+    this.#connected.value = status.connected
+  }
+
+  run = async <P>(
+    fn: ({
+      hexgate,
+      hx,
+      hfetch
+    }: {
+      hexgate: Hexgate
+      hx: ReturnType<T>
+      hfetch: (url: string) => Promise<Response>
+    }) => P
+  ): Promise<P> => {
+    return new Promise((resolve) => {
+      const resolvePromise = () =>
+        resolve(
+          fn({
+            hexgate: this.#hexgate!,
+            hx: this.#cookbook!,
+            hfetch: this.#hexfetch
+          })
+        )
+
+      if (this.connected) {
+        resolvePromise()
+      } else {
+        const unsubscribe = this.#connected.subscribe((connected, prev) => {
+          if (connected && !prev) {
+            unsubscribe()
+            resolvePromise()
+          }
+        })
+      }
+    })
+  }
+
+  #hexfetch = async (url: string) => {
+    if (!this.connected || !this.#credentials) {
+      throw new Error('Cannot fetch from LCU while disconnected')
+    }
+    // @ts-ignore
+    return fetch(`${this.#hexgate?.baseUrl}${url}`, this.#init)
+  }
+}

--- a/src/modules/runner/worker.ts
+++ b/src/modules/runner/worker.ts
@@ -1,0 +1,64 @@
+import { parentPort } from 'worker_threads'
+
+const port = parentPort
+if (!port) throw new Error('Invalid worker port')
+
+port.on('message', (e) => {
+  console.log('\n\nMESSAGE RECIEVED\n', e)
+})
+
+import { poll, auth, type Credentials, createRequestInit } from 'hexgate'
+
+let connected = false
+let status: 'connected' | 'disconnected' | 'connecting' = 'disconnected'
+let credentials: Credentials | undefined = undefined
+let timeout: NodeJS.Timeout
+let init: ReturnType<typeof createRequestInit> | undefined
+
+function pingLcu() {
+  const port = credentials?.appPort
+  if (!port) {
+    throw new Error('Worker thinks it is connected to LCU, but it is not!')
+  }
+  // @ts-ignore
+  return fetch(`https://127.0.0.1:${port}/lol-patch/v1/status`, init)
+}
+
+async function loop() {
+  timeout && clearTimeout(timeout)
+
+  if (!credentials) {
+    status = 'disconnected'
+    try {
+      const creds = await poll(auth, 2000, 5)
+      if (!creds) throw new Error('Unable to connect to LCU')
+      credentials = creds
+      init = createRequestInit(credentials)
+      status = 'connecting'
+      port?.postMessage({ status, connected, credentials })
+    } catch (e) {
+      connected = false
+      credentials = undefined
+      init = undefined
+      status = 'disconnected'
+    }
+  } else {
+    try {
+      const alive = await pingLcu()
+      if (alive.ok && !connected) {
+        connected = true
+        status = 'connected'
+        port?.postMessage({ status, connected, credentials })
+      }
+    } catch (e) {
+      connected = false
+      credentials = undefined
+      init = undefined
+      status = 'disconnected'
+      port?.postMessage({ status, connected, credentials })
+    }
+  }
+  timeout = setTimeout(loop, 2000)
+}
+
+setTimeout(loop, 2000)

--- a/src/utils/observable.ts
+++ b/src/utils/observable.ts
@@ -1,0 +1,26 @@
+export class Observable<T> {
+  #previousValue: T
+  #value: T
+  #listeners: ((value: T, previousValue: T) => void)[] = []
+  constructor(value: T) {
+    this.#previousValue = value
+    this.#value = value
+  }
+
+  get value() {
+    return this.#value
+  }
+
+  set value(value: T) {
+    this.#previousValue = this.#value
+    this.#value = value
+    this.#listeners.forEach((fn) => fn(value, this.#previousValue))
+  }
+
+  subscribe(fn: (value: T, previousValue: T) => void) {
+    this.#listeners.push(fn)
+    return () => {
+      this.#listeners = this.#listeners.filter((f) => f !== fn)
+    }
+  }
+}


### PR DESCRIPTION
This makes it easier to use the LCU without worrying about the connection status. `runner.run(api => sideEffects)`

```ts
import { Runner } from './modules/runner/index.js'
import { createRecipe } from './modules/hexgate/recipe.js'

const runner = new Runner(
  createRecipe(({ build, wrap }) => ({
    getCurrentSummoner: wrap(
      build('/lol-summoner/v1/current-summoner').method('get').create()
    )({
      async to(summoner) {
        const s = (await summoner).data as any as Omit<
          Awaited<typeof summoner>['data'],
          'summonerId'
        > & {
          summonerId: string
        }
        s.summonerId = s.summonerId?.toString()
        return s
      }
    })
  }))
)

runner.run(({ hx }) => {
  hx.getCurrentSummoner().then(console.log)
})

worker.on("message", runner.update)
```

Ideally, you would have a heartbeat worker thread post `StatusUpdate`s to the `Runner`, and then call `runner.update` with the status. There is an example worker in [`./src/modules/runner/worker.ts`](https://github.com/cuppachino/hexgate/blob/91f38a81d4becd9f5a4ba379bd4c7e7ac1b19758/src/modules/runner/worker.ts).

Without a worker, it works like this:

```ts
auth().then((credentials) => {
  runner.update({
    connected: true,
    credentials,
    status: 'connected'
  })
})
```