### PR TITLE
Export better lobby dtos & add them to event lookup

### DIFF
--- a/.changeset/quick-seahorses-hang.md
+++ b/.changeset/quick-seahorses-hang.md
@@ -1,0 +1,5 @@
+---
+"hexgate": patch
+---
+
+Export better lobby dtos & add them to event lookup

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export type * from './types/game-constants/ranked.js'
 export type { GameServerRegion } from './types/dto/game-server-region.js'
 export type { LcuResponseCode } from './types/dto/lcu-response-code.js'
 export type { LcuEvent, LcuEventLookup } from './types/dto/lcu-event-lookup.js'
+export type * from './types/dto/lobby.js'
 
 /// OpenAPI Types
 export type { LcuComponents } from './types/openapi/components.js'

--- a/src/modules/websocket/index.ts
+++ b/src/modules/websocket/index.ts
@@ -6,6 +6,7 @@ import type {
   LcuEvent,
   LcuEventLookup
 } from '../../types/dto/lcu-event-lookup.js'
+import type { LobbyEvent } from 'src/index.js'
 
 type RecordToCallbacks<T> = {
   [K in keyof T]: ({
@@ -19,7 +20,12 @@ type RecordToCallbacks<T> = {
   }) => void
 }
 
-type LcuWebSocketEventCallbacks = RecordToCallbacks<LcuEventLookup>
+type LcuWebSocketEventCallbacks = Omit<
+  RecordToCallbacks<LcuEventLookup>,
+  'OnJsonApiEvent_lol-lobby_v2_lobby'
+> & {
+  'OnJsonApiEvent_lol-lobby_v2_lobby': (event: LobbyEvent) => void
+}
 
 export interface ILcuClient {
   eventListeners: Partial<

--- a/src/types/dto/lcu-event-lookup.ts
+++ b/src/types/dto/lcu-event-lookup.ts
@@ -1,4 +1,5 @@
 import type { LcuComponents } from '../openapi/components.js'
+import type { LobbyEvent } from './lobby.js'
 
 export interface LcuEventLookup {
   /**
@@ -225,7 +226,7 @@ export interface LcuEventLookup {
   'OnJsonApiEvent_lol-lobby_v1_lobby': Record<string, unknown>
   'OnJsonApiEvent_lol-lobby_v2_comms': Record<string, unknown>
   'OnJsonApiEvent_lol-lobby_v2_eligibility': Record<string, unknown>
-  'OnJsonApiEvent_lol-lobby_v2_lobby': Record<string, unknown>
+  'OnJsonApiEvent_lol-lobby_v2_lobby': LobbyEvent
   'OnJsonApiEvent_lol-lobby_v2_party-active': Record<string, unknown>
   'OnJsonApiEvent_lol-login_v1_login-connection-state': Record<string, unknown>
   'OnJsonApiEvent_lol-login_v1_login-data-packet': Record<string, unknown>

--- a/src/types/dto/lobby.ts
+++ b/src/types/dto/lobby.ts
@@ -1,0 +1,88 @@
+import type { Combine } from '@cuppachino/type-space'
+import type { LcuComponents } from '../openapi/components.js'
+
+export interface LobbyDto
+  extends Combine<
+    LcuComponents['schemas']['LolLobbyLobbyDto'] & {
+      mucJwtDto?: {
+        channelClaim: string
+        domain: string
+        jwt: string
+        targetRegion: string
+      }
+      multiUserChatId?: string
+      multiUserChatPassword?: string
+    }
+  > {}
+
+export interface LobbyMemberDto
+  extends Combine<
+    LcuComponents['schemas']['LolLobbyLobbyParticipantDto'] & {
+      primaryChampionPreference?: number
+      secondaryChampionPreference?: number
+    }
+  > {}
+
+export interface LobbyCountdownDto {
+  countdown: number
+  enabled: boolean
+}
+
+export interface LobbyMatchmakingSearchState
+  extends Required<
+    LcuComponents['schemas']['LolLobbyLobbyMatchmakingSearchResource']
+  > {}
+
+export interface LobbyBotChampionDto
+  extends Required<LcuComponents['schemas']['LolLobbyLobbyBotChampion']> {}
+
+export interface LobbyInvitationDto
+  extends Required<LcuComponents['schemas']['LolLobbyLobbyInvitationDto']> {}
+
+/**
+ * Lobby events from the LCU websocket.
+ * ```
+ * OnJsonApiEvent_lol-lobby_v2_lobby
+ * ```
+ */
+export type LobbyEvent =
+  | {
+      data: LobbyDto
+      eventType: 'Create' | 'Update'
+      uri: '/lol-lobby/v2/lobby'
+    }
+  | {
+      data: null
+      eventType: 'Delete'
+      uri: '/lol-lobby/v2/lobby'
+    }
+  | {
+      data: LobbyMatchmakingSearchState
+      eventType: 'Update'
+      uri: '/lol-lobby/v2/lobby/matchmaking/search-state'
+    }
+  | {
+      data: LobbyMemberDto[]
+      eventType: 'Update'
+      uri: '/lol-lobby/v2/lobby/members'
+    }
+  | {
+      data: LobbyCountdownDto
+      eventType: 'Update'
+      uri: '/lol-lobby/v2/lobby/countdown'
+    }
+  | {
+      data: LobbyBotChampionDto[]
+      eventType: 'Update'
+      uri: '/lol-lobby/v2/lobby/custom/available-bots'
+    }
+  | {
+      data: boolean
+      eventType: 'Update'
+      uri: '/lol-lobby/v2/lobby/custom/bots-enabled'
+    }
+  | {
+      data: LobbyInvitationDto[]
+      eventType: 'Create' | 'Update' | 'Delete' // todo: verify
+      uri: '/lol-lobby/v2/lobby/invitations'
+    }

--- a/src/types/game-constants/queues.ts
+++ b/src/types/game-constants/queues.ts
@@ -391,6 +391,7 @@ export namespace Queue {
     Props<1200, 'Nexus Blitz', 'Nexus Blitz games', 'Deprecated in patch 9.2'>,
     Props<1300, 'Nexus Blitz', 'Nexus Blitz games', null>,
     Props<1400, "Summoner's Rift", 'Ultimate Spellbook games', null>,
+    Props<1700, 'CHERRY', 'Arena', null>,
     Props<1900, "Summoner's Rift", 'Pick URF games', null>,
     Props<2000, "Summoner's Rift", 'Tutorial 1', null>,
     Props<2010, "Summoner's Rift", 'Tutorial 2', null>,


### PR DESCRIPTION
This lets you use the `uri` to narrow the type of `data`.

example:
```ts
const client = new LcuClient(credentials)
client.subscribe("OnJsonApiEvent_lol-lobby_v2_lobby", handleLobby);

function handleLobby({ data, eventType, uri }: LobbyEvent) {
  switch (uri) {
    case "/lol-lobby/v2/lobby/invitations": {
      break;
    }
    case "/lol-lobby/v2/lobby": {
      break;
    }
    case "/lol-lobby/v2/lobby/matchmaking/search-state": {
      break;
    }
    case "/lol-lobby/v2/lobby/members": {
      break;
    }
    case "/lol-lobby/v2/lobby/countdown": {
      break;
    }
    case "/lol-lobby/v2/lobby/custom/available-bots": {
      break;
    }
    case "/lol-lobby/v2/lobby/custom/bots-enabled": {
      break;
    }
    default: {
      throw new Error("Unhandled lobby event" + JSON.stringify(event, null, 2));
    }
  }
```