### PR TITLE
add homepage to package.json

### DIFF
--- a/.changeset/serious-monkeys-jam.md
+++ b/.changeset/serious-monkeys-jam.md
@@ -1,0 +1,5 @@
+---
+'hexgate': patch
+---
+
+Add homepage to package.json so README appears on nmpjs

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "websocket",
     "typescript"
   ],
+  "homepage": "https://github.com/cuppachino/hexgate#readme",
   "author": "Jacob Bergholtz <cuppachino.dev@gmail.com>",
   "license": "GPL-3.0",
   "devDependencies": {


### PR DESCRIPTION
The project README isn't appearing on [npmjs](https://www.npmjs.com/package/hexgate).
[this](https://github.com/serverless/serverless/issues/3157) says it could be due to missing homepage field. Let's give it a shot.