### PR TITLE
Show how to export recipes

### DIFF
--- a/.changeset/sour-guests-doubt.md
+++ b/.changeset/sour-guests-doubt.md
@@ -1,0 +1,5 @@
+---
+"hexgate": minor
+---
+
+Show how to export recipes

--- a/README.md
+++ b/README.md
@@ -307,6 +307,33 @@ const summonersRecipe = createRecipe(({ build, wrap, unwrap }) => ({
 }))
 ```
 
+### Exporting Recipes
+
+If you want to export a recipe, you might get a type error. This is because the return type of `createRecipe` is inferred with references to `@cuppachino/openapi-fetch` and `node-fetch-commonjs`. To fix this, install the packages as dev dependencies and apply one of the following solutions to your `tsconfig.json`:
+
+#### Map paths
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@cuppachino/openapi-fetch": ["./node_modules/@cuppachino/openapi-fetch"],
+      "node-fetch-commonjs": ["./node_modules/node-fetch-commonjs"]
+    }
+  }
+}
+```
+
+#### Add types to the global scope
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@cuppachino/openapi-fetch", "node-fetch-commonjs"]
+  }
+}
+```
+
 ## Development
 
 This package uses [pnpm](https://pnpm.io) to manage dependencies. If you don't have pnpm, it can be installed globally using `npm`, `yarn`, `brew`, or `scoop`, as well as some other options. Check out the [pnpm documentation](https://pnpm.io/installation) for more information.

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "types": [
+      "@cuppachino/openapi-fetch", "node-fetch-commonjs"
+    ],
     "target": "ES2015",
     "lib": [
       "ES2015"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
     "rootDir": "src",
     "outDir": "dist/esm"
   },
+  "types": [
+    "@cuppachino/openapi-fetch", "node-fetch-commonjs"
+  ],
   "include": [
     "src"
   ],


### PR DESCRIPTION
This covers a common type error you get when trying to export `RecipeFn`s.

Such as:
```
The inferred type of `recipe` cannot be named without a reference to 
'.pnpm/@cuppachino+openapi-fetch@2.1.2/node_modules/@cuppachino/openapi-fetch'. 
This is likely not portable. A type annotation is necessary.
```